### PR TITLE
Enable Tailwind in frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ PORT=3001
 ```
 
 Estas variáveis são utilizadas pelo `server.js` para configurar a porta e a chave do JWT.
+
+## Frontend com Tailwind
+
+O frontend utiliza [Tailwind CSS](https://tailwindcss.com) para os estilos.
+Dentro da pasta `frontend` rode `npm install` para garantir que as dependências
+de desenvolvimento estejam instaladas e, em seguida, `npm start` para iniciar a
+aplicação em modo de desenvolvimento.
+
+Os estilos do Tailwind são definidos em `src/index.css` e compilados pelo
+`postcss` configurado em `postcss.config.js`.

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import { BrowserRouter } from "react-router-dom";
 import { AuthProvider } from "./context/authContext";
+import "./index.css";
 import "./css/style.css";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/**/*.{js,jsx}",
+    "./public/index.html"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- set up Tailwind CSS with PostCSS in the React frontend
- load Tailwind styles in `index.js`
- document Tailwind usage in README

## Testing
- `npm test -- --watchAll=false` in `frontend` *(fails: No tests found)*
- `npm test` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68405eb3dbfc832ebe83134bdc6de711