### PR TITLE
Refactor chat selection flow

### DIFF
--- a/frontend/src/components/ChatBubble.jsx
+++ b/frontend/src/components/ChatBubble.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import socket from "../socket";
-import ChatWindow from "./ChatWindow";
+import ChatPopup from "./ChatPopup";
 
 export default function ChatBubble() {
   const [open, setOpen] = useState(false);
@@ -44,7 +44,7 @@ export default function ChatBubble() {
           )}
         </div>
       </div>
-      {open && <ChatWindow onClose={toggle} />}
+      {open && <ChatPopup onClose={toggle} />}
     </>
   );
 }

--- a/frontend/src/components/ChatPopup.jsx
+++ b/frontend/src/components/ChatPopup.jsx
@@ -1,0 +1,25 @@
+import React, { useState } from "react";
+import ChatWindow from "./ChatWindow";
+import ConversationsList from "./ConversationsList";
+
+export default function ChatPopup({ onClose }) {
+  const [userId, setUserId] = useState(null);
+
+  return (
+    <div className="fixed bottom-16 right-4 bg-white shadow-lg rounded-lg w-80 max-h-[400px] flex text-sm z-50">
+      {userId ? (
+        <ChatWindow userId={userId} onClose={() => setUserId(null)} />
+      ) : (
+        <div className="flex-1 flex flex-col">
+          <div className="flex items-center justify-between p-2 border-b">
+            <span className="font-semibold">Conversas</span>
+            <button onClick={onClose} className="text-lg px-2">
+              ×
+            </button>
+          </div>
+          <ConversationsList onSelect={setUserId} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ChatWindow.jsx
+++ b/frontend/src/components/ChatWindow.jsx
@@ -26,7 +26,10 @@ export default function ChatWindow({ onClose, userId }) {
   }, [token]);
 
   useEffect(() => {
-    if (!userId || !friends.length) return;
+    if (!userId || !friends.length) {
+      setActive(null);
+      return;
+    }
     const f = friends.find((fr) => fr.id === Number(userId));
     if (f) setActive(f);
   }, [userId, friends]);
@@ -88,29 +91,19 @@ export default function ChatWindow({ onClose, userId }) {
   };
 
   const containerClasses = popup
-    ? "fixed bottom-16 right-4 bg-white shadow-lg rounded-lg w-72 max-h-[400px] flex flex-col text-sm"
+    ? "bg-white shadow-lg rounded-lg w-full max-h-[400px] flex flex-col text-sm"
     : "bg-white border rounded shadow flex flex-col h-full text-sm";
 
   return (
     <div className={containerClasses}>
       <div className="flex items-center justify-between p-2 border-b">
-        <select
-          className="flex-1 mr-2 border rounded px-1 py-0.5"
-          onChange={(e) =>
-            setActive(friends.find((f) => f.id === Number(e.target.value)))
-          }
-          value={active?.id || ""}
-        >
-          <option value="" disabled>
-            Escolha...
-          </option>
-          {friends.map((f) => (
-            <option key={f.id} value={f.id}>
-              {online.includes(f.id) ? "\u25CF " : "\u25CB "}
-              {f.name || f.first_name + " " + f.last_name}
-            </option>
-          ))}
-        </select>
+        <span className="flex-1 mr-2 truncate">
+          {active
+            ? `${online.includes(active.id) ? "\u25CF" : "\u25CB"} ${
+                active.name || active.first_name + " " + active.last_name
+              }`
+            : "Selecione um amigo"}
+        </span>
         {onClose && (
           <button onClick={onClose} className="text-lg px-2">
             ×


### PR DESCRIPTION
## Summary
- add chat popup component
- update chat bubble to show popup
- simplify chat window header and drop select menu

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*
- `(cd backend && npm test)` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686173f4a9d4832e9ae088efcd4bc8f9