### PR TITLE
Fix user profile names on Render

### DIFF
--- a/backend/controllers/postController.js
+++ b/backend/controllers/postController.js
@@ -44,7 +44,7 @@ export async function getPosts(req, res) {
   try {
     const posts = await allQuery(
       `
-      SELECT p.*, u.first_name || ' ' || u.last_name AS author, u.avatar_url, u.id AS authorId
+      SELECT p.*, u.first_name || ' ' || u.last_name AS author, u.avatar_url, u.id AS "authorId"
       FROM posts p
       JOIN users u ON u.id = p.user_id
       LEFT JOIN friendships f ON ((f.sender_id = ? AND f.receiver_id = p.user_id) OR (f.receiver_id = ? AND f.sender_id = p.user_id)) AND f.status = 'aceito'
@@ -64,7 +64,7 @@ export async function getMyPosts(req, res) {
   const userId = req.user.id;
   try {
     const posts = await allQuery(
-      `SELECT p.*, u.first_name || ' ' || u.last_name AS author, u.avatar_url, u.id AS authorId
+      `SELECT p.*, u.first_name || ' ' || u.last_name AS author, u.avatar_url, u.id AS "authorId"
       FROM posts p
       JOIN users u ON u.id = p.user_id
       WHERE p.user_id = ?
@@ -131,7 +131,7 @@ export function updatePost(io) {
 
     const [postAtualizado] = await allQuery(
       `
-      SELECT p.*, u.first_name || ' ' || u.last_name AS author, u.avatar_url, u.id AS authorId
+      SELECT p.*, u.first_name || ' ' || u.last_name AS author, u.avatar_url, u.id AS "authorId"
          FROM posts p
          JOIN users u ON u.id = p.user_id
         WHERE p.id = ?`,
@@ -176,7 +176,7 @@ export async function getPostsByUser(req, res) {
   try {
     const posts = await allQuery(
       `
-      SELECT p.*, u.first_name || ' ' || u.last_name AS author, u.avatar_url, u.id AS authorId
+      SELECT p.*, u.first_name || ' ' || u.last_name AS author, u.avatar_url, u.id AS "authorId"
       FROM posts p
       JOIN users u ON u.id = p.user_id
       LEFT JOIN friendships f 

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -15,8 +15,8 @@ export async function uploadAvatar(req, res) {
     ]);
     const [user] = await allQuery(
       `SELECT id,
-          first_name  AS firstName,
-          last_name   AS lastName,
+          first_name  AS "firstName",
+          last_name   AS "lastName",
           email,
           avatar_url  AS avatar_url,
           birth_date  AS birth_date
@@ -39,8 +39,8 @@ export async function removeAvatar(req, res) {
     await runQuery("UPDATE users SET avatar_url = NULL WHERE id = ?", [userId]);
     const [user] = await allQuery(
       `SELECT id,
-          first_name  AS firstName,
-          last_name   AS lastName,
+          first_name  AS "firstName",
+          last_name   AS "lastName",
           email,
           avatar_url  AS avatar_url,
           birth_date  AS birth_date
@@ -93,8 +93,8 @@ export async function updateProfile(req, res) {
 
     const [user] = await allQuery(
       `SELECT id,
-          first_name AS firstName,
-          last_name  AS lastName,
+          first_name AS "firstName",
+          last_name  AS "lastName",
           email,
           avatar_url,
           birth_date
@@ -121,8 +121,8 @@ export async function getUserById(req, res) {
     const [user] = await allQuery(
       `
       SELECT u.id,
-             u.first_name             AS firstName,
-             u.last_name              AS lastName,
+             u.first_name             AS "firstName",
+             u.last_name              AS "lastName",
              u.avatar_url,
              u.created_at,
              CASE
@@ -130,7 +130,7 @@ export async function getUserById(req, res) {
                WHEN f.status = 'pendente' AND f.sender_id   = ? THEN 'pendente'
                WHEN f.status = 'pendente' AND f.receiver_id = ? THEN 'recebido'
                ELSE 'nenhum'
-             END                       AS friendshipStatus
+             END                       AS "friendshipStatus"
       FROM   users u
       LEFT   JOIN friendships f
              ON ((f.sender_id = u.id AND f.receiver_id = ?)


### PR DESCRIPTION
## Summary
- preserve camelCase column aliases when querying Postgres so fields load correctly

## Testing
- `./setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68654ef767f4832ebff009dee4b91b20